### PR TITLE
feat: kill the Holster, add per-Claude MCP servers and handoff tool

### DIFF
--- a/backend/src/alpha_app/chat.py
+++ b/backend/src/alpha_app/chat.py
@@ -1,7 +1,6 @@
-"""Chat kernel — Chat + Holster for subprocess lifecycle management.
+"""Chat kernel — Chat subprocess lifecycle management.
 
 The Chat class wraps a Claude subprocess with a state machine and reap timer.
-The Holster keeps one warm subprocess ready for instant startup.
 
 State is a vector with two orthogonal dimensions:
   - Conversation: STARTING / READY / ENRICHING / RESPONDING / COLD
@@ -98,13 +97,13 @@ class Chat:
       suggest:      DISARMED / ARMED / FIRING
 
     Lifecycle:
-        from_holster()  -> (READY, DISARMED)
+        wake()          -> COLD -> STARTING -> READY (fresh start)
         begin_turn()    -> READY -> ENRICHING, suggest -> DISARMED
         send()          -> ENRICHING/READY -> RESPONDING (or interjection)
         events()        -> RESPONDING -> READY, suggest -> ARMED
         interrupt()     -> * -> COLD, suggest -> DISARMED
         reap()          -> * -> COLD, suggest -> DISARMED
-        resurrect()     -> COLD -> STARTING -> READY
+        resurrect()     -> COLD -> STARTING -> READY (resume existing session)
     """
 
     def __init__(self, *, id: str, claude: Claude | None = None) -> None:
@@ -143,14 +142,6 @@ class Chat:
         # Broadcast callback — called after reap so all clients see the state change.
         # Set externally by the WS handler. Signature: async (chat_id: str) -> None.
         self.on_reap: Callable[[str], Awaitable[None]] | None = None
-
-    @classmethod
-    def from_holster(cls, *, id: str, claude: Claude, system_prompt: str = "") -> "Chat":
-        """Create a Chat with a pre-warmed Claude. Born READY."""
-        chat = cls(id=id, claude=claude)
-        chat._system_prompt = system_prompt
-        chat._start_reap_timer()
-        return chat
 
     @classmethod
     def from_db(cls, chat_id: str, updated_at: float, data: dict) -> "Chat":
@@ -360,6 +351,35 @@ class Chat:
         self.state = ConversationState.COLD
         self.suggest = SuggestState.DISARMED
 
+    async def wake(
+        self,
+        system_prompt: str = "",
+        mcp_servers: dict[str, Any] | None = None,
+    ) -> None:
+        """Start a fresh Claude subprocess. COLD -> STARTING -> READY."""
+        if self.state != ConversationState.COLD:
+            raise RuntimeError(f"Can only wake COLD chats, not {self.state.value}")
+
+        prompt = system_prompt or self._system_prompt
+        self.state = ConversationState.STARTING
+
+        try:
+            self._claude = _make_claude(
+                model=MODEL,
+                system_prompt=prompt or None,
+                permission_mode="bypassPermissions",
+                mcp_servers=mcp_servers,
+            )
+            await self._claude.start(None)  # Fresh start, no resume
+
+            self.state = ConversationState.READY
+            self._needs_orientation = True
+            self._start_reap_timer()
+        except Exception:
+            self.state = ConversationState.COLD
+            self._claude = None
+            raise
+
     async def resurrect(
         self,
         system_prompt: str = "",
@@ -436,70 +456,3 @@ class Chat:
             pass
 
 
-class Holster:
-    """One in the chamber. Always keeps one warm claude subprocess ready."""
-
-    def __init__(
-        self,
-        system_prompt: str = "",
-        mcp_servers: dict[str, Any] | None = None,
-    ) -> None:
-        self._system_prompt = system_prompt
-        self._mcp_servers = mcp_servers or {}
-        self._warm: Claude | None = None
-        self._warming: asyncio.Task | None = None
-
-    @property
-    def ready(self) -> bool:
-        return self._warm is not None
-
-    async def warm(self) -> None:
-        """Start warming a new Claude in the background."""
-        if self._warming or self._warm:
-            return
-        self._warming = asyncio.create_task(self._do_warm())
-
-    async def _do_warm(self) -> None:
-        try:
-            claude = _make_claude(
-                model=MODEL,
-                system_prompt=self._system_prompt or None,
-                permission_mode="bypassPermissions",
-                mcp_servers=self._mcp_servers or None,
-            )
-            await claude.start(None)
-            self._warm = claude
-            self._warming = None
-        except Exception:
-            self._warming = None
-
-    async def claim(self) -> Claude:
-        """Take the warm Claude. Immediately start warming a replacement."""
-        if self._warm is not None:
-            claude = self._warm
-            self._warm = None
-            self._warming = None
-            await self.warm()
-            return claude
-
-        if self._warming is not None:
-            await self._warming
-            return await self.claim()
-
-        await self._do_warm()
-        return await self.claim()
-
-    async def shutdown(self) -> None:
-        if self._warming:
-            self._warming.cancel()
-            try:
-                await self._warming
-            except asyncio.CancelledError:
-                pass
-            self._warming = None
-        if self._warm:
-            try:
-                await self._warm.stop()
-            except Exception:
-                pass
-            self._warm = None

--- a/backend/src/alpha_app/main.py
+++ b/backend/src/alpha_app/main.py
@@ -21,8 +21,7 @@ from fastapi.staticfiles import StaticFiles
 
 from alpha_app import assemble_system_prompt
 from alpha_app.memories import init_schema as init_cortex_schema, close as close_cortex
-from alpha_app.tools import create_cortex_server
-from alpha_app.chat import Chat, ConversationState, Holster
+from alpha_app.chat import Chat, ConversationState
 from alpha_app.db import init_pool, close_pool
 from alpha_app.routes.sessions import router as sessions_router
 from alpha_app.routes.ws import router as ws_router
@@ -33,7 +32,7 @@ logfire.configure(service_name="alpha-app", scrubbing=False)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-    """App lifespan — assemble system prompt, warm holster, clean shutdown."""
+    """App lifespan — assemble system prompt, clean shutdown."""
     # Startup
     await init_pool()
 
@@ -48,18 +47,9 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     except (RuntimeError, FileNotFoundError):
         soul = ""
 
-    # Create Cortex MCP server — memory tools served in-process
-    cortex_server = create_cortex_server()
-    mcp_servers = {"cortex": cortex_server}
-
-    holster = Holster(system_prompt=soul, mcp_servers=mcp_servers)
-    app.state.holster = holster
     app.state.chats = {}  # dict[str, Chat]
     app.state.connections = set()  # set[WebSocket] — all live WS connections (the switch)
     app.state.system_prompt = soul  # Stored for resurrection
-    app.state.mcp_servers = mcp_servers  # Stored for resurrection
-
-    await holster.warm()
 
     yield
 
@@ -67,7 +57,6 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     for chat in list(app.state.chats.values()):
         if chat.state != ConversationState.COLD:
             await chat.reap()
-    await holster.shutdown()
     await close_cortex()
     await close_pool()
 
@@ -96,13 +85,11 @@ app.include_router(ws_router)
 @app.get("/health")
 async def health() -> dict:
     """Health check endpoint."""
-    holster: Holster = app.state.holster
     chats: dict[str, Chat] = app.state.chats
     alive = [c for c in chats.values() if c.state != ConversationState.COLD]
     busy = [c for c in chats.values() if c.state in (ConversationState.ENRICHING, ConversationState.RESPONDING)]
     return {
         "status": "healthy",
-        "holster_ready": holster.ready,
         "chats_total": len(chats),
         "chats_alive": len(alive),
         "chats_busy": len(busy),

--- a/backend/src/alpha_app/routes/handlers.py
+++ b/backend/src/alpha_app/routes/handlers.py
@@ -8,7 +8,7 @@ import asyncio
 
 from fastapi import WebSocket
 
-from alpha_app.chat import Chat, ConversationState, Holster, generate_chat_id
+from alpha_app.chat import Chat, ConversationState, generate_chat_id
 from alpha_app.db import list_chats, persist_chat
 from alpha_app.routes.broadcast import broadcast
 
@@ -16,16 +16,14 @@ from alpha_app.routes.broadcast import broadcast
 async def handle_create_chat(
     ws: WebSocket,
     connections: set,
-    holster: Holster,
     chats: dict[str, Chat],
     on_reap,
 ) -> None:
-    """Handle create-chat: claim from holster, persist, broadcast to all."""
+    """Handle create-chat: born COLD, persist, broadcast to all."""
     try:
-        claude = await holster.claim()
         chat_id = generate_chat_id()
-        system_prompt = ws.app.state.system_prompt
-        chat = Chat.from_holster(id=chat_id, claude=claude, system_prompt=system_prompt)
+        chat = Chat(id=chat_id)
+        chat._system_prompt = ws.app.state.system_prompt
         chat.on_reap = on_reap
         chats[chat_id] = chat
 

--- a/backend/src/alpha_app/routes/turn.py
+++ b/backend/src/alpha_app/routes/turn.py
@@ -23,6 +23,7 @@ from alpha_app.routes.broadcast import broadcast
 from alpha_app.routes.enrobe import enrobe
 from alpha_app.routes.spans import build_prompt_preview, format_input_messages
 from alpha_app.routes.streaming import stream_chat_events
+from alpha_app.tools import create_cortex_server, create_handoff_server
 
 
 async def handle_new_turn(
@@ -62,17 +63,13 @@ async def handle_new_turn(
         },
     ) as span:
         try:
-            # -- Resurrect if COLD -----------------------------------------
+            # -- Wake or resurrect if COLD ---------------------------------
             resurrected = False
             if chat.state == ConversationState.COLD:
-                if not chat.session_uuid:
-                    await broadcast(connections, {
-                        "type": "error",
-                        "chatId": chat_id,
-                        "data": "Chat is cold with no session to resume",
-                    })
-                    await broadcast(connections, {"type": "done", "chatId": chat_id})
-                    return
+                # Create per-Claude MCP servers
+                cortex = create_cortex_server()
+                handoff = create_handoff_server(chat)
+                mcp_servers = {"cortex": cortex, "handoff": handoff}
 
                 await broadcast(connections, {
                     "type": "chat-state",
@@ -84,11 +81,21 @@ async def handle_new_turn(
                         "contextWindow": chat.context_window,
                     },
                 })
-                await chat.resurrect(
-                    system_prompt=ws.app.state.system_prompt,
-                    mcp_servers=getattr(ws.app.state, "mcp_servers", None),
-                )
-                resurrected = True
+
+                if not chat.session_uuid:
+                    # Fresh chat — first message ever
+                    await chat.wake(
+                        system_prompt=ws.app.state.system_prompt,
+                        mcp_servers=mcp_servers,
+                    )
+                else:
+                    # Resumed chat — has a session to continue
+                    await chat.resurrect(
+                        system_prompt=ws.app.state.system_prompt,
+                        mcp_servers=mcp_servers,
+                    )
+                    resurrected = True
+
                 await broadcast(connections, {
                     "type": "chat-state",
                     "chatId": chat_id,

--- a/backend/src/alpha_app/routes/ws.py
+++ b/backend/src/alpha_app/routes/ws.py
@@ -21,7 +21,7 @@ Server -> Client messages (unicast — response to requester only):
   { "type": "chat-list", "data": [...] }
 
 Server -> Client messages (broadcast — all connections):
-  { "type": "chat-created", "chatId": "...", "data": { "state": "idle" } }
+  { "type": "chat-created", "chatId": "...", "data": { "state": "dead" } }  -- born COLD, wakes on first message
   { "type": "chat-state", "chatId": "...", "data": { "state": "busy", "title": "...", ... } }
   { "type": "user-message", "chatId": "...", "data": { "content": [...] } }
   { "type": "text-delta", "chatId": "...", "data": "chunk" }
@@ -40,7 +40,7 @@ from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
 from alpha_app import AssistantEvent, UserEvent, replay_session
 
-from alpha_app.chat import Chat, ConversationState, Holster
+from alpha_app.chat import Chat, ConversationState
 from alpha_app.db import get_pool, load_chat
 from alpha_app.routes.broadcast import broadcast
 from alpha_app.routes.handlers import handle_create_chat, handle_interrupt, handle_list_chats
@@ -76,7 +76,6 @@ async def websocket_chat(ws: WebSocket) -> None:
     connections: set = ws.app.state.connections
     connections.add(ws)
 
-    holster: Holster = ws.app.state.holster
     chats: dict[str, Chat] = ws.app.state.chats
 
     # Reap callback — when a chat's idle timer fires, broadcast DEAD to all.
@@ -97,7 +96,7 @@ async def websocket_chat(ws: WebSocket) -> None:
             msg_type = raw.get("type")
 
             if msg_type == "create-chat":
-                await handle_create_chat(ws, connections, holster, chats, on_chat_reap)
+                await handle_create_chat(ws, connections, chats, on_chat_reap)
 
             elif msg_type == "list-chats":
                 await handle_list_chats(ws, chats)

--- a/backend/src/alpha_app/tools/__init__.py
+++ b/backend/src/alpha_app/tools/__init__.py
@@ -5,5 +5,6 @@ No external MCP server processes — just dict in, dict out.
 """
 
 from .cortex import create_cortex_server
+from .handoff import create_handoff_server
 
-__all__ = ["create_cortex_server"]
+__all__ = ["create_cortex_server", "create_handoff_server"]

--- a/backend/src/alpha_app/tools/handoff.py
+++ b/backend/src/alpha_app/tools/handoff.py
@@ -1,0 +1,63 @@
+"""Handoff tool — per-Chat MCP server for graceful context window transitions.
+
+The handoff server holds a reference to its Chat. When Alpha calls the
+handoff tool, it can reach chat.send() directly — no contextvars,
+no global lookup.
+
+Usage:
+    from alpha_app.tools.handoff import create_handoff_server
+
+    server = create_handoff_server(chat)
+    # Pass to Claude(mcp_servers={"handoff": server})
+"""
+
+from mcp.server.fastmcp import FastMCP
+
+
+def create_handoff_server(chat) -> FastMCP:
+    """Create a per-Chat handoff MCP server.
+
+    The server holds a reference to its Chat. When Alpha calls the
+    handoff tool, it can reach chat.send() directly — no contextvars,
+    no global lookup.
+    """
+    server = FastMCP("handoff")
+
+    @server.tool(
+        description=(
+            "Hand off your context. Call this when you're ready to gracefully "
+            "transition to a fresh context window. Pass instructions telling "
+            "the summarizer what to focus on — what's still in progress, "
+            "what's finished, what matters most for future-you."
+        ),
+    )
+    async def handoff(instructions: str, memory: str) -> str:
+        """Store a last memory, then queue /compact + wake-up on stdin."""
+        from ..memories.cortex import store as cortex_store
+
+        result = await cortex_store(memory)
+        if result is None:
+            return "Error storing memory — handoff aborted"
+        memory_id = result.get("id", "?")
+
+        # Queue /compact on stdin. Chat is RESPONDING during tool dispatch,
+        # so send() goes through the interjection path (write to stdin, no state change).
+        await chat.send([{"type": "text", "text": f"/compact {instructions}"}])
+
+        # Queue the wake-up message. It survives the compaction boundary —
+        # the summary gets buffered and piggybacks on this message.
+        wake_up = (
+            "You've just been through a context compaction. "
+            "Jeffery is here and listening. "
+            "Orient yourself — read the summary above, check in, "
+            "ask questions if anything's unclear."
+        )
+        await chat.send([{"type": "text", "text": wake_up}])
+
+        return (
+            f"Memory #{memory_id} stored. "
+            "/compact sent — context transition initiated. "
+            "Last thoughts — say what you need to say."
+        )
+
+    return server


### PR DESCRIPTION
Closes #12: removes the Holster pattern, adds per-Claude MCP servers, and introduces the handoff tool for graceful context window transitions.

Generated with [Claude Code](https://claude.ai/code)