### PR TITLE
feat: auto-rebuild frontend when source is newer than dist bundle

### DIFF
--- a/backend/src/alpha_app/main.py
+++ b/backend/src/alpha_app/main.py
@@ -116,11 +116,45 @@ if FRONTEND_DIR.is_dir():
         return FileResponse(FRONTEND_DIR / "index.html")
 
 
+def _rebuild_frontend_if_stale(frontend_dir: Path) -> None:
+    """Run `npm run build` if any frontend/src file is newer than dist/index.html.
+
+    This is only called on bare-metal (not Docker). The timestamp check is the
+    only cost on a clean restart — subprocess is not spawned unless needed.
+    """
+    import subprocess
+
+    src_dir = frontend_dir / "src"
+    dist_index = frontend_dir / "dist" / "index.html"
+
+    if not src_dir.is_dir():
+        return  # Nothing to build
+
+    if dist_index.exists():
+        dist_mtime = dist_index.stat().st_mtime
+        stale = any(
+            p.stat().st_mtime > dist_mtime
+            for p in src_dir.rglob("*")
+            if p.is_file()
+        )
+        if not stale:
+            return
+
+    print("Frontend source has changed — rebuilding…", flush=True)
+    result = subprocess.run(["npm", "run", "build"], cwd=frontend_dir, check=False)
+    if result.returncode != 0:
+        print(f"Warning: frontend build exited with code {result.returncode}", flush=True)
+
+
 def run() -> None:
     """Entry point for `uv run alpha` (bare metal deployment)."""
     import uvicorn
 
     from alpha_app.constants import PORT
+
+    # Rebuild frontend if source is newer than the bundle (bare-metal only).
+    if not _DOCKER_DIST.is_dir():
+        _rebuild_frontend_if_stale(_LOCAL_DIST.parent)
 
     ssl_certfile = os.getenv("SSL_CERTFILE")
     ssl_keyfile = os.getenv("SSL_KEYFILE")


### PR DESCRIPTION
Before starting uvicorn on bare metal, check whether any file under `frontend/src/` has a newer mtime than `frontend/dist/index.html`. If so, run `npm run build`. The timestamp walk is the only cost on a clean restart — no subprocess is spawned unless the bundle is stale.

Closes #16

Generated with [Claude Code](https://claude.ai/code)