### PR TITLE
fix: disable New Chat button while a pending chat exists

### DIFF
--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -6,7 +6,7 @@
  * "New Chat" navigates to /chat which triggers auto-create in Layout.
  */
 
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { Plus } from "lucide-react";
 import {
@@ -139,6 +139,13 @@ export function AppSidebar({ onNewChat }: AppSidebarProps) {
     [sortedChats]
   );
 
+  // Optimistic pending state: disable the button immediately on click so rapid
+  // double-clicks are blocked even before the WebSocket round-trip completes.
+  const [isPending, setIsPending] = useState(false);
+  useEffect(() => {
+    if (hasUnusedChat) setIsPending(false);
+  }, [hasUnusedChat]);
+
   const handleChatClick = useCallback(
     (id: string) => {
       navigate(`/chat/${id}`);
@@ -148,6 +155,7 @@ export function AppSidebar({ onNewChat }: AppSidebarProps) {
   );
 
   const handleNewChat = useCallback(() => {
+    setIsPending(true);
     onNewChat();
     if (isMobile) setOpenMobile(false);
   }, [onNewChat, isMobile, setOpenMobile]);
@@ -160,7 +168,7 @@ export function AppSidebar({ onNewChat }: AppSidebarProps) {
             <SidebarMenuButton
               onClick={handleNewChat}
               tooltip="New chat"
-              disabled={hasUnusedChat}
+              disabled={isPending || hasUnusedChat}
               className={isEmpty && !hasUnusedChat ? "animate-breathe" : undefined}
             >
               <Plus size={16} />


### PR DESCRIPTION
Closes #22

Extends the existing "New Chat" guard in `AppSidebar.tsx` to also block the button while a chat is in "starting" state, preventing rapid double-clicks from opening multiple empty chats before the first subprocess finishes warming up.

Generated with [Claude Code](https://claude.ai/code)