### PR TITLE
fix: move memory card ellipsis from line 2 to line 3

### DIFF
--- a/frontend/src/components/MemoryCard.tsx
+++ b/frontend/src/components/MemoryCard.tsx
@@ -95,7 +95,7 @@ export function MemoryCard({ memory, flat = false }: MemoryCardProps) {
               className="w-full h-12 object-cover object-top rounded-sm mt-0.5 opacity-80"
             />
           ) : preview ? (
-            <div className="text-[12px] text-text/70 leading-tight line-clamp-2 h-12 overflow-hidden">
+            <div className="text-[12px] text-text/70 leading-tight line-clamp-3 h-12 overflow-hidden">
               {preview}
             </div>
           ) : null}


### PR DESCRIPTION
Fixes #68

Changed `line-clamp-2` to `line-clamp-3` on the memory card text div so the ellipsis appears at the end of the third line, matching the card's visible height.

Generated with [Claude Code](https://claude.ai/code)