### PR TITLE
feat: syntax highlighting for code blocks via react-shiki

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
     "react-dom": "^19.2.3",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.11.0",
+    "react-shiki": "^0.9.1",
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",

--- a/frontend/src/components/assistant-ui/shiki-highlighter.tsx
+++ b/frontend/src/components/assistant-ui/shiki-highlighter.tsx
@@ -1,0 +1,27 @@
+/**
+ * SyntaxHighlighter — wraps react-shiki for use with assistant-ui's
+ * MarkdownTextPrimitive. Uses the `vesper` theme: warm dark, amber accents,
+ * background close to our --theme-code-bg (#101010 vs #161616).
+ *
+ * The component is debounced internally by react-shiki so highlighting
+ * doesn't fire on every streaming delta — only after the code settles.
+ */
+import { ShikiHighlighter } from "react-shiki";
+
+interface SyntaxHighlighterProps {
+  children: string;
+  language: string | undefined;
+  className?: string;
+}
+
+export function SyntaxHighlighter({ children, language }: SyntaxHighlighterProps) {
+  return (
+    <ShikiHighlighter
+      language={language ?? "text"}
+      theme="vesper"
+      delay={150}
+    >
+      {children}
+    </ShikiHighlighter>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -130,6 +130,13 @@
   font-size: 0.85em;
 }
 
+/* Shiki-highlighted blocks: shiki sets its own background-color inline,
+   which overrides our CSS background above. The rest (padding, border-radius,
+   font, overflow) still applies. Reset the line-height to match shiki's spans. */
+.markdown-text .shiki {
+  line-height: 1.6;
+}
+
 .markdown-text pre code {
   font-family: inherit;
   font-size: inherit;

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -46,7 +46,8 @@ import type {
   ThreadMessageLike,
   AppendMessage,
 } from "@assistant-ui/react";
-import { MarkdownTextPrimitive } from "@assistant-ui/react-markdown";
+import { MarkdownTextPrimitive, memoizeMarkdownComponents } from "@assistant-ui/react-markdown";
+import { SyntaxHighlighter } from "../components/assistant-ui/shiki-highlighter";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import {
@@ -232,11 +233,16 @@ const ThinkingBlock = ({ text, status }: { text: string; status: unknown }) => {
 // An inline object literal in JSX is recreated every render, which breaks
 // Parts' internal memoization and forces child unmount/remount.
 // Native assistant-ui markdown text with smooth streaming + GFM
+const markdownComponents = memoizeMarkdownComponents({
+  SyntaxHighlighter,
+});
+
 const NativeMarkdownText = () => (
   <MarkdownTextPrimitive
     remarkPlugins={[remarkGfm]}
     className="markdown-text"
     smooth
+    components={markdownComponents}
   />
 );
 


### PR DESCRIPTION
Adds syntax highlighting to fenced code blocks in assistant messages using react-shiki and the vesper theme.

- New `shiki-highlighter.tsx` component wrapping react-shiki
- Wired into `MarkdownTextPrimitive` via `memoizeMarkdownComponents`
- 150ms debounce so highlighting doesn't fire on every streaming delta
- Language detected from fenced code block markers (```python, ```bash, etc.)
- Vesper theme: warm dark with amber accents, matches app palette

Closes #37

Generated with [Claude Code](https://claude.ai/code)