### PR TITLE
feat: support HEIC image uploads from iPhone

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "python-frontmatter>=1.1.0",
     "python-dotenv>=1.0.0",
     "Pillow>=11.0.0",
+    "pillow-heif>=0.18.0",
     "APScheduler>=3.10.0,<4",
     "numpy>=2.4.3",
     "aiobotocore>=2.20.0",

--- a/backend/src/alpha_app/images.py
+++ b/backend/src/alpha_app/images.py
@@ -14,12 +14,17 @@ import base64
 import io
 
 from PIL import Image, ImageOps
+from pillow_heif import register_heif_opener
+
+register_heif_opener()
 
 _MAX_PIXELS = 1_000_000  # 1 megapixel threshold
 _JPEG_QUALITY = 85
 
 # Media types that should be JPEG-compressed even when under 1MP
-_LOSSLESS_MEDIA_TYPES = frozenset({"image/png", "image/gif", "image/webp", "image/bmp", "image/tiff"})
+_LOSSLESS_MEDIA_TYPES = frozenset(
+    {"image/png", "image/gif", "image/webp", "image/bmp", "image/tiff", "image/heic", "image/heif"}
+)
 
 
 def process_image_block(block: dict) -> dict:


### PR DESCRIPTION
Add HEIC/HEIF image support via `pillow-heif` so iPhone photos can be attached directly without manual format conversion.

Changes:
- Add `pillow-heif>=0.18.0` to `backend/pyproject.toml`
- Register HEIF opener on import in `images.py`
- Add `image/heic` and `image/heif` to `_LOSSLESS_MEDIA_TYPES` so they get JPEG-compressed

Closes #52

Generated with [Claude Code](https://claude.ai/code)