### PR TITLE
chore: repo scaffolding for v1.0.0 planning

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+<!--
+Summary, Why, Test plan. Keep it tight.
+
+Privacy: commit messages and code comments are public (repo is public).
+Keep Jeffery's private texture in memories and diary, not in code or
+commit messages.
+-->
+
+## Summary
+
+<!-- What does this PR do? One or two sentences. -->
+
+## Why
+
+<!-- The reason — what problem does this solve, or what does it enable? -->
+
+## Test plan
+
+<!-- How did you verify this works? What did you run, what did you see? -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to Alpha-App land here. Format loosely follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
+semver where practical. One entry per user-visible change. Internal refactors
+and plumbing go in Git.
+
+## [Unreleased]
+
+### Added
+
+- GitHub Milestones for release planning: `v1.0.0 (fork-ready)`, `v1.x`, `Someday`.
+- GitHub Labels for cross-cutting concerns: `fork-blocker`, `epic`, `frontend`, `backend`, `infra`.
+- Branch protection on `main` (PR required; admin bypass enabled).
+- PR template at `.github/pull_request_template.md` (Summary / Why / Test plan).
+- This file.
+
+### Changed
+
+- *Ongoing:* planning for v1.0.0 underway. See the `v1.0.0 (fork-ready)` milestone.
+
+[Unreleased]: https://github.com/Pondsiders/Alpha-App/commits/main


### PR DESCRIPTION
## Summary

Adds three-section PR template, CHANGELOG.md, and lands the first entries describing today's repo-planning scaffolding (milestones, labels, branch protection — configured separately via gh API).

## Why

We're about to file a dozen new issues and reorganize the existing 15 under milestones for v1.0.0 planning (War Plan Rosemary). Before that, put the structural pieces in place: a PR template to enforce Summary/Why/Test plan discipline, a CHANGELOG as the human-readable history, and an example PR (this one) that dogfoods the template.

## Test plan

- PR template renders when this PR was opened (visible above).
- CHANGELOG.md renders correctly on GitHub.
- Once merged, the `repo-setup` branch will be auto-deleted (after we turn on delete_branch_on_merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)