### PR TITLE
chore: CHANGELOG entry for War Plan Rosemary setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,15 @@ and plumbing go in Git.
 - GitHub Labels for cross-cutting concerns: `fork-blocker`, `epic`, `frontend`, `backend`, `infra`.
 - Branch protection on `main` (PR required; admin bypass enabled).
 - PR template at `.github/pull_request_template.md` (Summary / Why / Test plan).
-- This file.
+- `delete_branch_on_merge` enabled at the repo level — merged PR branches auto-delete.
+- **War Plan Rosemary**: 30 new issues filed and the existing 15 reconciled into milestones. Pinned roadmap tracker at #117.
+  - 4 epics (Streaming redesign #87, Dead-code audit #88, MCP functional decomposition #89, Tool components as a system #90)
+  - 18 sub-issues linked via GitHub's native sub-issue API
+  - 12 standalone issues across v1.0.0, v1.x, and Someday
+- `CHANGELOG.md` (this file).
 
 ### Changed
 
-- *Ongoing:* planning for v1.0.0 underway. See the `v1.0.0 (fork-ready)` milestone.
+- **Planning for v1.0.0 is live.** See the [v1.0.0 (fork-ready) milestone](https://github.com/Pondsiders/Alpha-App/milestone/1) and the [pinned roadmap](https://github.com/Pondsiders/Alpha-App/issues/117).
 
 [Unreleased]: https://github.com/Pondsiders/Alpha-App/commits/main


### PR DESCRIPTION
## Summary

Records today's War Plan Rosemary setup in `CHANGELOG.md`: 30 new issues, milestone reconciliation, pinned roadmap tracker (#117).

## Why

The CHANGELOG is the human-readable record of what happened. Today was a planning day with zero code changes but significant structural work on the repo — worth a bookmark for future retrospection.

## Test plan

- [x] CHANGELOG renders correctly on GitHub.
- [x] Pinned roadmap #117 is reachable.
- [x] Milestone #1 shows correct issues.